### PR TITLE
修复企业微信模式无法启动的问题

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,7 +14,7 @@ RUN cp /usr/share/zoneinfo/Asia/Shanghai /etc/localtime && \
 WORKDIR /bot
 COPY requirements.txt /bot/requirements.txt
 RUN pip install -r requirements.txt
-RUN pip install https://github.com/jxtech/wechatpy/archive/master.zip
+# RUN pip install https://github.com/jxtech/wechatpy/archive/master.zip
 # RUN pip install -i https://mirrors.aliyun.com/pypi/simple/ -r requirements.txt
 
 FROM develop AS release

--- a/kokkoro/bot/wechat_enterprise/__init__.py
+++ b/kokkoro/bot/wechat_enterprise/__init__.py
@@ -5,6 +5,6 @@ kkr_bot = None
 def get_bot():
     global kkr_bot
     if kkr_bot == None:
-        from kokkoro.wechat_enterprise.bot import KokkoroWechatEpBot
+        from kokkoro.bot.wechat_enterprise.bot import KokkoroWechatEpBot
         kkr_bot = KokkoroWechatEpBot(config)
     return kkr_bot

--- a/kokkoro/bot/wechat_enterprise/bot.py
+++ b/kokkoro/bot/wechat_enterprise/bot.py
@@ -10,7 +10,7 @@ from wechatpy.messages import BaseMessage
 import kokkoro
 from kokkoro.typing import overrides
 from kokkoro.common_interface import KokkoroBot, EventInterface, SupportedMessageType
-from kokkoro.wechat_enterprise.wechat_enterprise_adaptor import WechatEpEvent
+from kokkoro.bot.wechat_enterprise.wechat_enterprise_adaptor import WechatEpEvent
 
 def wechat_handler(bot):
     async def wrapper():

--- a/kokkoro/bot/wechat_enterprise/wechat_enterprise_adaptor.py
+++ b/kokkoro/bot/wechat_enterprise/wechat_enterprise_adaptor.py
@@ -3,6 +3,7 @@ from wechatpy.messages import BaseMessage
 from kokkoro.util import to_string
 from kokkoro.common_interface import EventInterface
 from kokkoro import config
+from kokkoro.typing import overrides
 
 class WechatEpEvent(EventInterface):
     def __init__(self, raw_event: BaseMessage):

--- a/kokkoro/modules/arknights/recruit.py
+++ b/kokkoro/modules/arknights/recruit.py
@@ -124,7 +124,7 @@ async def _async_init():
             sv.logger.error("Fail to load recruit info of arknights")
 
 loop = asyncio.new_event_loop()
-loop.run_in_executor(_async_init())
+loop.run_until_complete(_async_init())
 
 HELP_MESSAGE = '请输入标签。默认仅显示必得4★的TAG组合\n示例：公开招募 位移 近战位\n显示所有可能干员请使用参数"-a"或"全部"\n示例：公开招募 -a 位移 近战位\n网页版：https://www.bigfun.cn/tools/aktools-old/akhr.html'
 @sv.on_prefix(('ark-recruit','公开招募', "公招"))

--- a/kokkoro/modules/arknights/recruit.py
+++ b/kokkoro/modules/arknights/recruit.py
@@ -123,7 +123,8 @@ async def _async_init():
         else:
             sv.logger.error("Fail to load recruit info of arknights")
 
-asyncio.run(_async_init())
+loop = asyncio.new_event_loop()
+loop.run_in_executor(_async_init())
 
 HELP_MESSAGE = '请输入标签。默认仅显示必得4★的TAG组合\n示例：公开招募 位移 近战位\n显示所有可能干员请使用参数"-a"或"全部"\n示例：公开招募 -a 位移 近战位\n网页版：https://www.bigfun.cn/tools/aktools-old/akhr.html'
 @sv.on_prefix(('ark-recruit','公开招募', "公招"))

--- a/kokkoro/modules/weibo/weibo.py
+++ b/kokkoro/modules/weibo/weibo.py
@@ -22,7 +22,8 @@ class WeiboSpider(object):
         self.received_weibo_ids = []
         self.last_5_weibos = []
         self.__recent = False
-        asyncio.run(self._async_init())
+        self._loop = asyncio.new_event_loop()
+        self._loop.run_until_complete(self._async_init())
     
     async def _async_init(self):
         self.__init = True

--- a/requirements.txt
+++ b/requirements.txt
@@ -16,6 +16,6 @@ quart>=0.13.0
 APScheduler>=2.1.2
 pytz>=2020.1
 zhconv>=1.4.0
-
+wechatpy==2.0.0a1
 nest-asyncio>=1.4.0
 tomon-sdk==0.1.6


### PR DESCRIPTION
1. 依赖wechatpy>2，否则无企业微信work支持
2. 修复arknights, weibo插件异步调用后关闭主线程event loop导致quart无法启动的问题
3. 修复overrides import的问题
4. dockerfile中注释wechatpy依赖（2.0.0a1已经发布到pip